### PR TITLE
RISC-V: Do not use vsetivli for THeadVector.

### DIFF
--- a/gcc/config/riscv/riscv-v.cc
+++ b/gcc/config/riscv/riscv-v.cc
@@ -394,7 +394,7 @@ emit_vlmax_insn_lra (unsigned icode, unsigned insn_flags, rtx *ops, rtx vl)
   gcc_assert (!can_create_pseudo_p ());
   machine_mode mode = GET_MODE (ops[0]);
 
-  if (imm_avl_p (mode))
+  if (imm_avl_p (mode) && !TARGET_XTHEADVECTOR)
     {
       /* Even though VL is a real hardreg already allocated since
 	 it is post-RA now, we still gain benefits that we emit

--- a/gcc/testsuite/gcc.target/riscv/rvv/xtheadvector/pr120461.c
+++ b/gcc/testsuite/gcc.target/riscv/rvv/xtheadvector/pr120461.c
@@ -1,0 +1,6 @@
+/* { dg-do compile } */
+/* { dg-options "-mcpu=xt-c920 -mrvv-vector-bits=zvl -fzero-call-used-regs=all" */
+
+void
+foo ()
+{}


### PR DESCRIPTION
in emit_vlmax_insn_lra we use a vsetivli for an immediate AVL. XTHeadVector does not support this, so guard appropriately.

Regtested on rv64gcv_zvl512b.

Regards
 Robin

	PR target/120461

gcc/ChangeLog:

	* config/riscv/riscv-v.cc (emit_vlmax_insn_lra): Do not emit vsetivli for XTHeadVector.

gcc/testsuite/ChangeLog:

	* gcc.target/riscv/rvv/xtheadvector/pr120461.c: New test.

Thanks for taking the time to contribute to GCC! Please be advised that if you are
viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
The GCC community does not use `github.com` for their contributions. Instead, we use
a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
bug reports. Please send patches there instead.

## Summary by Sourcery

Guard use of immediate-AVL vsetivli in RISC-V VL-max emission so it is not used for XTHeadVector targets and add a regression test for the reported issue.

Bug Fixes:
- Avoid emitting vsetivli with immediate AVL for XTHeadVector RISC-V targets, which do not support this instruction form.

Tests:
- Add a RISC-V RVV XTHeadVector test to verify compilation with immediate AVL handling and zeroing of call-used registers.